### PR TITLE
Feature/gitignore and rebuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.repo/
+components/
+
+.pre-commit-config.yaml
+Makefile.container.includes

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,112 @@
+{
+  "version": "1.4.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "results": {},
+  "generated_at": "2024-06-11T15:40:17Z"
+}

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 # This .tool-versions file does not contribute to software installed within this container. 
-# To add software to the base image, see the .tool-versions file at 
-# https://github.com/launchbynttdata/launch-build-agent-base/blob/main/.tool-versions
+# To add software to the base image, edit the .tool-versions file in the launch-build-agent-base
+# repository.

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,3 @@
+# This .tool-versions file does not contribute to software installed within this container. 
+# To add software to the base image, see the .tool-versions file at 
+# https://github.com/launchbynttdata/launch-build-agent-base/blob/main/.tool-versions

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,18 +6,19 @@ ENV CONTAINER_REGISTRY="ghcr.io/launchbynttdata" \
     CONTAINER_IMAGE_NAME="launch-build-agent-aws" \
     CONTAINER_IMAGE_VERSION="latest"
 
-ENV TOOLS_DIR="/usr/local/opt" \
+ENV TOOLS_DIR="/home/launch/tools" \
     IS_PIPELINE=true
 
 # Allows us to rerun repo sync in the AWS manifest context
 RUN rm -fr .repo/ components/
 
+COPY ./.tool-versions "${TOOLS_DIR}/launch-build-agent/.tool-versions"
 COPY "./Makefile" "${TOOLS_DIR}/launch-build-agent/Makefile"
 ENV BUILD_ACTIONS_DIR="${TOOLS_DIR}/launch-build-agent/components/build-actions" \
     PATH="$PATH:${BUILD_ACTIONS_DIR}" \
     JOB_NAME="${GIT_USERNAME}" \
     JOB_EMAIL="${GIT_USERNAME}@${GIT_EMAIL_DOMAIN}"
-RUN cd /usr/local/opt/launch-build-agent \
+RUN cd "${TOOLS_DIR}/launch-build-agent" \
     && make git-config \
     && make configure
 


### PR DESCRIPTION
Adds a .gitignore, .secrets.baseline, and .tool-versions to ensure `make configure` works.

Mostly rebuilds the container from the latest base image.