### PR TITLE
bounce build

### DIFF
--- a/.github/workflows/build-container.yaml
+++ b/.github/workflows/build-container.yaml
@@ -15,7 +15,7 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - name: Delete huge unnecessary tools folder
+      - name: Delete huge unnecessary tools folder # https://github.com/orgs/community/discussions/25678#discussioncomment-5242449
         run: rm -rf /opt/hostedtoolcache
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
- build bounce for latest `launch-cli`
- Removing unused tools dir for this github action as we are hitting the 14gb space limit